### PR TITLE
Fixes a bug in large messages where xCE was left on the end

### DIFF
--- a/src/serena/frameparser.py
+++ b/src/serena/frameparser.py
@@ -198,7 +198,7 @@ class FrameParser:
             # packet finished, construct frame from saved values
             self._processing_partial_packet = False
             frame = self._make_frame(
-                self._saved_type, self._saved_channel, bytes(self._last_packet_buffer)
+                self._saved_type, self._saved_channel, bytes(body)
             )
             self._last_packet_buffer = bytearray()
 


### PR DESCRIPTION
When decoding a large message from the queue, our JSON parser was reporting an extra `xCE` on the end.

`next_frame` has two main branches. When processing a partial packet, the existing code strips the frame termination octet out of `body` but does not return that modified body. The `else` does return the modified body.

This PR makes the partial packet condition return the string with the frame terminator removed.